### PR TITLE
recipes-multimedia: Use https protocol for cloning git

### DIFF
--- a/recipes-multimedia/gst-shark/gst-shark_0.2.1.bb
+++ b/recipes-multimedia/gst-shark/gst-shark_0.2.1.bb
@@ -6,8 +6,13 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=e1caa368743492879002ad032445fa97"
 DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad "
 
 SRCBRANCH ?= "master"
-SRCREV = "64ca36ffc211d09059dec872ddab74de75af8a24"
-SRC_URI = "git://git@github.com/RidgeRun/gst-shark.git;protocol=ssh;branch=${SRCBRANCH}"
+SRC_URI = " \
+	git://git@github.com/RidgeRun/gst-shark.git;protocol=https;branch=${SRCBRANCH};name=base \
+	git://git@anongit.freedesktop.org/gstreamer/common;protocol=https;destsuffix=git/common;name=common; \
+	"
+
+SRCREV_base = "64ca36ffc211d09059dec872ddab74de75af8a24"
+SRCREV_common = "b64f03f6090245624608beb5d2fff335e23a01c0"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-multimedia/gstd_1.0/gstd_1.0.bb
+++ b/recipes-multimedia/gstd_1.0/gstd_1.0.bb
@@ -7,7 +7,7 @@ DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad gstre
 
 SRCBRANCH ?= "master"
 SRCREV = "097a086a8606dcb368c7d38c7ec4fefc2497401b"
-SRC_URI = "git://git@github.com/RidgeRun/gstd-1.x.git;protocol=ssh;branch=${SRCBRANCH} \
+SRC_URI = "git://git@github.com/RidgeRun/gstd-1.x.git;protocol=https;branch=${SRCBRANCH} \
 	   file://0001-gstd-yocto-compatibility.patch"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Use https protocol for cloning gst-shark,gstreamer/common
and gstd repositories as https URL's can work behind
firewalls or proxy and thus are more universally accessible
as compare to ssh which require setting up SSH keypair prior
to usage.

Signed-off-by: Devarsh Thakkar <devarsht@xilinx.com>