### PR TITLE
recipes-multimedia: Use git prefix for the common submodule URL

### DIFF
--- a/recipes-multimedia/gst-shark/gst-shark_0.2.1.bb
+++ b/recipes-multimedia/gst-shark/gst-shark_0.2.1.bb
@@ -10,10 +10,9 @@ SRCBRANCH ?= "master"
 SRCREV_base = "64ca36ffc211d09059dec872ddab74de75af8a24"
 SRCREV_common = "b64f03f6090245624608beb5d2fff335e23a01c0"
 
-SRC_URI[common.md5sum] = "7cf52612fd700cc554bf3f2e497602f7"
 SRC_URI = " \
     git://git@github.com/RidgeRun/gst-shark.git;protocol=https;branch=${SRCBRANCH};name=base \
-    https://anongit.freedesktop.org/git/gstreamer/common.git;protocol=https;destsuffix=git/common;name=common; \
+    git://anongit.freedesktop.org/git/gstreamer/common.git;protocol=https;destsuffix=git/common;name=common; \
     "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Use git prefix for the gstreamer/common URL as
without this the git clone method was not being used
for cloning the common submodule.

Also remove SRC_URI md5sum as it is not needed for
common anymore after using the git prefix as yocto now
correctly uses the git instead of assuming the
https URL as tarball.

Signed-off-by: Devarsh Thakkar <devarsht@xilinx.com>