### PR TITLE
 Feature/add v4l2 pcie driver recipe

### DIFF
--- a/recipes-kernel/pcie-fpga-v4l2/pcie-fpga-v4l2_0.1.0.bb
+++ b/recipes-kernel/pcie-fpga-v4l2/pcie-fpga-v4l2_0.1.0.bb
@@ -1,0 +1,23 @@
+SUMMARY = "PCI-E driver module for FPGA with V4L2 support"
+DESCRIPTION = "Allows to send and retrieve data using Video for Linux from FPGA graphics accelerators connected through PCI-e using DMA transfers"
+HOMEPAGE = "https://developer.ridgerun.com/wiki/index.php?title=V4L2_PCIe"
+LICENSE = "Propietary"
+
+LIC_FILES_CHKSUM = "file://copyrights.xml;md5=ade31ec14bee4ad39dd1a4c9f3a8f226"
+
+inherit module
+
+export PLATFORM = "xilinx"
+
+SRCBRANCH ?= "master"
+SRCREV = "113aa33260f65532027b0ff915d4453bf3227761"
+SRC_URI = " git://git@gitlab.com/RidgeRun/orders/<Customer-Directory>/pcie-fpga-v4l2.git;protocol=ssh;branch=${SRCBRANCH}"
+
+S = "${WORKDIR}/git/"
+
+FILES_${PN} += "${libdir}/*"
+
+do_install () {
+	install -d ${D}/lib/modules/${KERNEL_VERSION}/
+	install -m 0644 ${WORKDIR}/git/xilinx/xilinx.ko ${D}/lib/modules/${KERNEL_VERSION}/
+}

--- a/recipes-kernel/pcie-fpga-v4l2/pcie-fpga-v4l2_0.1.0.bb
+++ b/recipes-kernel/pcie-fpga-v4l2/pcie-fpga-v4l2_0.1.0.bb
@@ -1,5 +1,5 @@
 SUMMARY = "PCI-E driver module for FPGA with V4L2 support"
-DESCRIPTION = "Allows to send and retrieve data using Video for Linux from FPGA graphics accelerators connected through PCI-e using DMA transfers"
+DESCRIPTION = "Allows to send and retrieve data using V4L2 API from FPGA graphics accelerators connected through PCI-e using DMA transfers"
 HOMEPAGE = "https://developer.ridgerun.com/wiki/index.php?title=V4L2_PCIe"
 LICENSE = "Propietary"
 

--- a/recipes-kernel/pcie-fpga-v4l2/pcie-fpga-v4l2_0.1.0.bb
+++ b/recipes-kernel/pcie-fpga-v4l2/pcie-fpga-v4l2_0.1.0.bb
@@ -7,8 +7,8 @@ LIC_FILES_CHKSUM = "file://copyrights.xml;md5=ade31ec14bee4ad39dd1a4c9f3a8f226"
 
 inherit module
 
+# Set your settings here
 export PLATFORM = "xilinx"
-
 SRCBRANCH ?= "master"
 SRCREV = "113aa33260f65532027b0ff915d4453bf3227761"
 SRC_URI = " git://git@gitlab.com/RidgeRun/orders/<Customer-Directory>/pcie-fpga-v4l2.git;protocol=ssh;branch=${SRCBRANCH}"

--- a/recipes-kernel/pcie-fpga-v4l2/pcie-fpga-v4l2_0.1.0.bb
+++ b/recipes-kernel/pcie-fpga-v4l2/pcie-fpga-v4l2_0.1.0.bb
@@ -15,7 +15,7 @@ SRC_URI = " git://git@gitlab.com/RidgeRun/orders/<Customer-Directory>/pcie-fpga-
 
 S = "${WORKDIR}/git/"
 
-FILES_${PN} += "${libdir}/*"
+FILES_${PN} += "${libdir}/modules/${KERNEL_VERSION}/${PLATFORM}.ko"
 
 do_install () {
 	install -d ${D}/lib/modules/${KERNEL_VERSION}/

--- a/recipes-kernel/pcie-fpga-v4l2/pcie-fpga-v4l2_0.1.0.bb
+++ b/recipes-kernel/pcie-fpga-v4l2/pcie-fpga-v4l2_0.1.0.bb
@@ -10,7 +10,7 @@ inherit module
 # Set your settings here
 export PLATFORM = "xilinx"
 SRCBRANCH ?= "master"
-SRCREV = "113aa33260f65532027b0ff915d4453bf3227761"
+SRCREV = "41a884ba98f5eee4b642b764fca39cf34468fdd1"
 SRC_URI = " git://git@gitlab.com/RidgeRun/orders/<Customer-Directory>/pcie-fpga-v4l2.git;protocol=ssh;branch=${SRCBRANCH}"
 
 S = "${WORKDIR}/git/"

--- a/recipes-kernel/pcie-fpga-v4l2/pcie-fpga-v4l2_0.1.0.bb
+++ b/recipes-kernel/pcie-fpga-v4l2/pcie-fpga-v4l2_0.1.0.bb
@@ -19,5 +19,5 @@ FILES_${PN} += "${libdir}/*"
 
 do_install () {
 	install -d ${D}/lib/modules/${KERNEL_VERSION}/
-	install -m 0644 ${WORKDIR}/git/xilinx/xilinx.ko ${D}/lib/modules/${KERNEL_VERSION}/
+	install -m 0644 ${WORKDIR}/git/${PLATFORM}/${PLATFORM}.ko ${D}/lib/modules/${KERNEL_VERSION}/
 }


### PR DESCRIPTION
This feature adds the recipe for compiling the driver module for FPGA accelerators connected through PCI-e with V4L2 support.