### PR TITLE
Add SRCREV_FORMAT so that SRCREV changes are properly stamped

### DIFF
--- a/recipes-multimedia/gstreamer/gst-webrtc_1.11.2.bb
+++ b/recipes-multimedia/gstreamer/gst-webrtc_1.11.2.bb
@@ -10,6 +10,7 @@ DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad json-
 
 SRCBRANCH ?= "master"
 
+SRCREV_FORMAT = "base_common"
 SRCREV_base = "e92de7a5c14428fdf7d6be31e31c21fca89c345a"
 SRCREV_common = "b64f03f6090245624608beb5d2fff335e23a01c0"
 


### PR DESCRIPTION
Without the SRCREV_FORMAT variable, changes in the SRCREV variable are
ignored because of the multiple named git repositories present in the
SRC_URI file.