### PR TITLE
Hotfix/misc fixes

### DIFF
--- a/recipes-multimedia/gstreamer/gst-isp_1.0.bb
+++ b/recipes-multimedia/gstreamer/gst-isp_1.0.bb
@@ -11,8 +11,8 @@ DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gst-opencl"
 #provided by Ridgerun with your order.
 #######
 SRCBRANCH ?= "master"
-SRCREV = "" 
-CUSTOMER = 
+SRCREV = ""
+CUSTOMER = ""
 SRC_URI = " git://git@gitlab.com/RidgeRun/orders/${CUSTOMER}/gst-isp.git;protocol=ssh;branch=${SRCBRANCH}"
 
 S = "${WORKDIR}/git"

--- a/recipes-multimedia/gstreamer/gst-opencl_0.2.bb
+++ b/recipes-multimedia/gstreamer/gst-opencl_0.2.bb
@@ -11,8 +11,8 @@ DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad imx-g
 #provided by Ridgerun with your order.
 #######
 SRCBRANCH ?= "master"
-SRCREV = "" 
-CUSTOMER = 
+SRCREV = ""
+CUSTOMER = ""
 SRC_URI = " git://git@gitlab.com/RidgeRun/orders/${CUSTOMER}/gst-opencl.git;protocol=ssh;branch=${SRCBRANCH}"
 
 

--- a/recipes-multimedia/usrsctp/usrsctp_0.9.3.bb
+++ b/recipes-multimedia/usrsctp/usrsctp_0.9.3.bb
@@ -13,6 +13,8 @@ SRC_URI = " \
 
 S = "${WORKDIR}/git"
 
+DEBUG_BUILD="1"
+
 inherit autotools pkgconfig gettext
 
 do_configure() {


### PR DESCRIPTION
The fixes are the following:

- **Fix parsing errors in gst-isp and gst-opencl recipes**: It doesn't matter the Yocto release, parsing errors will appear to everyone who attemps to use this meta layer if gst-isp_1.0.bb  and gst-opencl_0.2.bb  aren't corrected.

- **Override optimization level for usrsctp package**: In newer Yocto releases usrsctp has compilation errors (the issue appeared in thud release). The workaround is to override optimizations for this package.  Specifically the error that will appear in several files will be:

`error: #warning _FORTIFY_SOURCE requires compiling with optimization (-O) [-Werror=cpp]`