### PR TITLE
Add recipe for gst-sei

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,24 @@ bitbake gst-opencl
 - For more information:
     https://www.ridgerun.com/gstopencl
 
+## Building Gst-SEI (Private)
+
+- GstSEI is a GStreamer element to insert and extract metadata on NAL Units
+    https://shop.ridgerun.com/products/gstseimetadata
+
+- Once you have access to the repository, please open gst-sei_0.2.2.bb in **$YOCTO_DIRECTORY/sources/meta-ridgerun/recipes-multimedia/gstreamer/**
+
+- Modify SRC_URI with the correct gst-sei URL by changing **<Customer-Directory>** with your own.
+
+- Make sure you have added your ssh key to your GitLab account and the GitLab key is added to your list of known hosts on the PC.
+
+- Finally build recipe
+```
+bitbake gst-sei
+```
+- For more information:
+    https://developer.ridgerun.com/wiki/index.php?title=GstSEIMetadata
+
 ### iMX6 build
 
 If you are building for an iMX6 board, make sure you have the **imx-gst1.0-plugin** and **gstreamer1.0-plugins-imx** packages.

--- a/recipes-multimedia/gstreamer/gst-sei_0.2.2.bb
+++ b/recipes-multimedia/gstreamer/gst-sei_0.2.2.bb
@@ -8,9 +8,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=2207b8e5f4ab4b3a0c794e43f2002ea3"
 
 DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad"
 
-SRCBRANCH ?= "master"
-SRCREV = "bab4334f41f08efba78af2244449370cc6861654"
-SRC_URI = " git://git@gitlab.com/RidgeRun/orders/<Customer-Directory>/gst-sei.git;protocol=ssh;branch=${SRCBRANCH}"
+SRCTAG ?= "v${PV}"
+SRC_URI = " git://git@gitlab.com/RidgeRun/orders/<Customer-Directory>/gst-sei.git;protocol=ssh;tag=${SRCTAG}"
 
 FILES_${PN} += "\
         ${libdir}/gstreamer-1.0/libsei.so \

--- a/recipes-multimedia/gstreamer/gst-sei_0.2.2.bb
+++ b/recipes-multimedia/gstreamer/gst-sei_0.2.2.bb
@@ -1,0 +1,25 @@
+SUMMARY = "GStreamer SEI"
+DESCRIPTION = "GStreamer element to insert and extract metadata on NAL Units"
+HOMEPAGE = "https://developer.ridgerun.com/wiki/index.php?title=GstSEIMetadata"
+SECTION = "multimedia"
+LICENSE = "Proprietary"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=2207b8e5f4ab4b3a0c794e43f2002ea3"
+
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad"
+
+SRCBRANCH ?= "master"
+SRCREV = "bab4334f41f08efba78af2244449370cc6861654"
+SRC_URI = " git://git@gitlab.com/RidgeRun/orders/<Customer-Directory>/gst-sei.git;protocol=ssh;branch=${SRCBRANCH}"
+
+FILES_${PN} += "\
+        ${libdir}/gstreamer-1.0/libsei.so \
+        ${libdir}/libgstsei.so \
+"
+
+S = "${WORKDIR}/git"
+
+EXTRA_OEMESON = " -Ddoc=disabled -Dtests=disabled -Dexamples=disabled"
+
+inherit meson pkgconfig
+


### PR DESCRIPTION
This feature adds the recipe for the GstSEI plugin.

The documentation and the examples are disabled to avoid build errors. The examples build error for IMX is due to a **g_strdup_printf** which format is not taking into account the platform. Another Merge Request was created in the GstSEI repository to fix this. Then, when it's merged into master via a release, the examples can be enabled.