### PR TITLE
Updated gst-interpipes recipe to compile using meson

### DIFF
--- a/recipes-multimedia/gstreamer/gst-interpipes_v1.1.8.bb
+++ b/recipes-multimedia/gstreamer/gst-interpipes_v1.1.8.bb
@@ -1,4 +1,4 @@
-SUMMARY = "Gstreamer Interpipes 1.1.8"
+SUMMARY = "Gstreamer Interpipe 1.1.8"
 DESCRIPTION = "GStreamer plug-in that allows communication between two independent pipelines"
 HOMEPAGE = "https://developer.ridgerun.com/wiki/index.php?title=GstInterpipe"
 SECTION = "multimedia"
@@ -6,7 +6,7 @@ LICENSE = "LGPL2.1"
 
 LIC_FILES_CHKSUM = "file://COPYING;md5=3191ae9476980e87e3494d2d8ebe4584"
 
-DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base"
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gtk-doc-native"
 
 SRCBRANCH ?= "master"
 SRCREV = "${PV}"
@@ -16,9 +16,6 @@ S = "${WORKDIR}/git"
 
 FILES_${PN} += "${libdir}/gstreamer-1.0/libgstinterpipe.so "
 
-inherit autotools pkgconfig gettext
+EXTRA_OEMESON = "-Denable-gtk-doc=false"
 
-do_configure() {
-    ${S}/autogen.sh --noconfigure
-    oe_runconf
-}
+inherit meson


### PR DESCRIPTION
This Pull Request:

- Update the gst-interpipes recipe to build using meson.
- Also, the recipe disable the use of gtk-doc tool