### PR TITLE
Add support for gst-cuda and gst-stitcher

### DIFF
--- a/recipes-multimedia/gstreamer/files/0001-simplify-CUDA-library-detection-and-NVCC-flag-setup.patch
+++ b/recipes-multimedia/gstreamer/files/0001-simplify-CUDA-library-detection-and-NVCC-flag-setup.patch
@@ -1,0 +1,60 @@
+From dae373eabe501270efcb1b13735899b61ddbd002 Mon Sep 17 00:00:00 2001
+From: omendez <oscar.mendez@ridgerun.com>
+Date: Mon, 13 Oct 2025 08:45:59 -0600
+Subject: [PATCH] simplify CUDA library detection and NVCC flag setup
+
+---
+ m4/gst-cuda.m4 | 36 +++++++++++++++++-------------------
+ 1 file changed, 17 insertions(+), 19 deletions(-)
+
+diff --git a/m4/gst-cuda.m4 b/m4/gst-cuda.m4
+index ef33fc1..5966511 100644
+--- a/m4/gst-cuda.m4
++++ b/m4/gst-cuda.m4
+@@ -34,26 +34,24 @@ AC_DEFUN([AG_GST_CHECK_NVCC],
+     AC_MSG_ERROR([No nvcc compiler found, specify CUDA location using --with-cuda-prefix])
+   fi
+ 
+-  AC_CHECK_FILE([$with_cuda_prefix/lib64],[lib64_found=yes],[lib64_found=no])
+-  if test "x$lib64_found" = xno ; then
+-    AC_CHECK_FILE([$with_cuda_prefix/lib],[lib32_found=yes],[lib32_found=no])
+-    if test "x$lib32_found" = xno ; then
+-      AC_MSG_ERROR([Couldn't find cuda lib directory])
+-    fi
+-  else
+-    AC_CHECK_SIZEOF([long])
+-    if test "x$ac_cv_sizeof_long" = "x8" ; then
+-      NVCC_CFLAGS+=" -m64"
+-    elif test "x$ac_cv_sizeof_long" = "x4" ; then
+-      AC_CHECK_FILE([$with_cuda_prefix/lib32],[lib32_found=yes],[lib32_found=no])
+-      if test "x$lib32_found" = xyes ; then
+-        NVCC_CFLAGS+=" -m32"
+-      else
+-        AC_MSG_ERROR([Couldn't find cuda lib directory])
+-      fi
+-    else
+-      AC_MSG_ERROR([Could not determine size of long variable type])
++  cuda_libdir_found=no
++  for cuda_lib_candidate in lib64 lib lib32; do
++    if test -d "$with_cuda_prefix/$cuda_lib_candidate"; then
++      cuda_libdir_found=yes
++      case $cuda_lib_candidate in
++        lib32)
++          NVCC_CFLAGS="$NVCC_CFLAGS -m32"
++          ;;
++        *)
++          NVCC_CFLAGS="$NVCC_CFLAGS -m64"
++          ;;
++      esac
++      break
+     fi
++  done
++
++  if test "x$cuda_libdir_found" = xno ; then
++    AC_MSG_ERROR([Couldn't find cuda lib directory])
+   fi
+ 
+   NVCC_CFLAGS+=" -O3 -arch=sm_50 -Xcompiler -Wall -Xcompiler -Wextra --ptxas-options=-v"
+-- 
+2.34.1
+

--- a/recipes-multimedia/gstreamer/files/gstcudastitcher.patch
+++ b/recipes-multimedia/gstreamer/files/gstcudastitcher.patch
@@ -1,0 +1,13 @@
+diff --git a/gst/stitcher/gstcudastitcher.cpp b/gst/stitcher/gstcudastitcher.cpp
+index c9191eb..db6c43a 100644
+--- a/gst/stitcher/gstcudastitcher.cpp
++++ b/gst/stitcher/gstcudastitcher.cpp
+@@ -29,7 +29,7 @@
+ #include <gst/base/gstaggregator.h>
+ #include <gst/gst.h>
+ #include <gst/video/video.h>
+-#include <jsoncpp/json/json.h>
++#include <json/json.h>
+ #include <sys/cuda/gstcuda.h>
+ 
+ #include <sys/cuda/muxalgorithm.hpp>

--- a/recipes-multimedia/gstreamer/gst-cuda.bb
+++ b/recipes-multimedia/gstreamer/gst-cuda.bb
@@ -1,0 +1,47 @@
+SUMMARY = "RidgeRun GStreamer CUDA plug-in framework"
+DESCRIPTION = "GstCUDA provides base classes and helper utilities to integrate CUDA algorithms into GStreamer 1.0 pipelines."
+HOMEPAGE = "https://github.com/RidgeRun/gst-cuda"
+SECTION = "multimedia"
+
+LICENSE = "CLOSED"
+
+SRCBRANCH ?= "main"
+SRCREV = "${AUTOREV}"
+
+#TODO:Change the SRC_URI to point the actual repository of gst-cuda
+SRC_URI = " \
+    gitsm://gst-cuda-repository;protocol=ssh;branch=${SRCBRANCH} \
+    file://0001-simplify-CUDA-library-detection-and-NVCC-flag-setup.patch \
+"
+
+S = "${WORKDIR}/git"
+
+inherit autotools cuda pkgconfig
+
+DEPENDS = " \
+    cuda-toolkit-native \
+    cuda-cudart-native \
+    glib-2.0 \
+    gstreamer1.0 \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-bad \
+    tegra-mmapi \
+"
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[gtk-doc] = "--enable-gtk-doc,--disable-gtk-doc,gtk-doc-native"
+PACKAGECONFIG[nvmm]    = "--enable-nvmm,--disable-nvmm,"
+PACKAGECONFIG[examples] = "--enable-examples,--disable-examples,"
+
+EXTRA_OECONF += " \
+    ${@bb.utils.contains('PACKAGECONFIG', 'gtk-doc', '', '--disable-gtk-doc', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'nvmm', '', '--disable-nvmm', d)} \
+"
+
+EXTRA_OECONF += "${@bb.utils.contains('PACKAGECONFIG', 'nvmm', \
+    '--with-nvidia-multimedia-api-prefix=${STAGING_INCDIR}/ \
+     --with-nvidia-prefix=${STAGING_LIBDIR}/ \
+     --with-nvidia-egl-prefix=${STAGING_LIBDIR}/', \
+    '', d)}"
+
+FILES:${PN} += "${libdir}/gstreamer-1.0/"

--- a/recipes-multimedia/gstreamer/gst-cuda.bb
+++ b/recipes-multimedia/gstreamer/gst-cuda.bb
@@ -8,7 +8,8 @@ LICENSE = "CLOSED"
 SRCBRANCH ?= "main"
 SRCREV = "${AUTOREV}"
 
-#TODO:Change the SRC_URI to point the actual repository of gst-cuda
+# Note: This SRC_URI points to RidgeRun's internal repository. Should
+# replace it with the repository URI provided to them upon purchase of the plugin.
 SRC_URI = " \
     gitsm://gst-cuda-repository;protocol=ssh;branch=${SRCBRANCH} \
     file://0001-simplify-CUDA-library-detection-and-NVCC-flag-setup.patch \
@@ -29,19 +30,12 @@ DEPENDS = " \
 "
 
 PACKAGECONFIG ??= ""
-PACKAGECONFIG[gtk-doc] = "--enable-gtk-doc,--disable-gtk-doc,gtk-doc-native"
-PACKAGECONFIG[nvmm]    = "--enable-nvmm,--disable-nvmm,"
+PACKAGECONFIG[gtk-doc]  = "--enable-gtk-doc,--disable-gtk-doc,gtk-doc-native"
+PACKAGECONFIG[nvmm]     = "--enable-nvmm \
+                           --with-nvidia-multimedia-api-prefix=${STAGING_INCDIR}/ \
+                           --with-nvidia-prefix=${STAGING_LIBDIR}/ \
+                           --with-nvidia-egl-prefix=${STAGING_LIBDIR}/, \
+                           --disable-nvmm,"
 PACKAGECONFIG[examples] = "--enable-examples,--disable-examples,"
-
-EXTRA_OECONF += " \
-    ${@bb.utils.contains('PACKAGECONFIG', 'gtk-doc', '', '--disable-gtk-doc', d)} \
-    ${@bb.utils.contains('PACKAGECONFIG', 'nvmm', '', '--disable-nvmm', d)} \
-"
-
-EXTRA_OECONF += "${@bb.utils.contains('PACKAGECONFIG', 'nvmm', \
-    '--with-nvidia-multimedia-api-prefix=${STAGING_INCDIR}/ \
-     --with-nvidia-prefix=${STAGING_LIBDIR}/ \
-     --with-nvidia-egl-prefix=${STAGING_LIBDIR}/', \
-    '', d)}"
 
 FILES:${PN} += "${libdir}/gstreamer-1.0/"

--- a/recipes-multimedia/gstreamer/gst-stitcher.bb
+++ b/recipes-multimedia/gstreamer/gst-stitcher.bb
@@ -8,7 +8,8 @@ SRCBRANCH ?= "main"
 SRCREV = "${AUTOREV}"
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-#TODO:Change the SRC_URI to point the actual repository of gst-stitcher
+# Note: This SRC_URI points to RidgeRun's internal repository. Should
+# replace it with the repository URI provided to them upon purchase of the plugin.
 SRC_URI = " \
     git://gst-cuda-stitcher-repository;protocol=ssh;branch=${SRCBRANCH} \
     file://gstcudastitcher.patch \

--- a/recipes-multimedia/gstreamer/gst-stitcher.bb
+++ b/recipes-multimedia/gstreamer/gst-stitcher.bb
@@ -1,0 +1,54 @@
+SUMMARY = "RidgeRun Stitching framework for image stitching with CUDA support"
+DESCRIPTION = "Framework to perform stitching of different input images with CUDA backend support"
+HOMEPAGE = "https://developer.ridgerun.com/wiki/index.php/Image_Stitching_for_NVIDIA_Jetson/Getting_Started/Evaluating_the_Stitcher"
+SECTION = "multimedia"
+LICENSE = "CLOSED"
+
+SRCBRANCH ?= "main"
+SRCREV = "${AUTOREV}"
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+#TODO:Change the SRC_URI to point the actual repository of gst-stitcher
+SRC_URI = " \
+    git://gst-cuda-stitcher-repository;protocol=ssh;branch=${SRCBRANCH} \
+    file://gstcudastitcher.patch \
+"
+
+S = "${WORKDIR}/git"
+
+inherit meson cuda pkgconfig
+
+DEPENDS = " \
+    cuda-toolkit-native \
+    cuda-cudart-native \
+    glib-2.0 \
+    gstreamer1.0 \
+    gstreamer1.0-plugins-base \
+    gst-cuda \
+    opencv \
+    cpputest \
+    gtk+ \
+    pre-commit-native \
+    pkgconfig-native \
+    jsoncpp \
+"
+
+PACKAGECONFIG ??= "gst-stitcher ocvcuda profile-code nvmm"
+PACKAGECONFIG[tests] = "-Dtests=enabled,-Dtests=disabled"
+PACKAGECONFIG[examples] = "-Dexamples=enabled,-Dexamples=disabled"
+PACKAGECONFIG[ocvcuda] = "-Docvcuda=enabled,-Docvcuda=disabled"
+PACKAGECONFIG[profile-code] = "-Dprofile-code=enabled,-Dprofile-code=disabled"
+PACKAGECONFIG[gst-stitcher] = "-Dgst-stitcher=enabled,-Dgst-stitcher=disabled"
+PACKAGECONFIG[eval] = "-Deval=enabled,-Deval=disabled"
+PACKAGECONFIG[nvmm] = "-Denable-nvmm=true,-Denable-nvmm=false"
+PACKAGECONFIG[developer-mode] = "-Ddeveloper-mode=true,-Ddeveloper-mode=false"
+
+EXTRA_OEMESON += " --buildtype=release"
+
+RDEPENDS:${PN} += "gst-cuda"
+
+INSANE_SKIP:${PN} = "rpaths"
+LDFLAGS[unexport] = "1"
+EXEWRAPPER_ENABLED:class-target = "False"
+
+FILES:${PN} += "${libdir}/gstreamer-1.0/*.so*"


### PR DESCRIPTION
# Modifications Performed

- Create the recipes to add support for `gst-cuda` and `gst-stitcher`

# Tests

## gst-cuda
```
Plugin Details:
  Name                     cuda
  Description              Allows frames to be processed by the GPU using a custom CUDA library algorithm
  Filename                 /usr/lib/gstreamer-1.0/libgstcuda.so
  Version                  0.16.5.1
  License                  Proprietary
  Source module            gst-cuda
  Source release date      2025-10-13 14:54 (UTC)
  Binary package           GStreamer CUDA Plug-in
  Origin URL               Unknown package origin

  cudafilter: cudafilter
  cudamux: cudamux

  2 features:
  +-- 2 elements

```

## gst-stitcher

```
Factory Details:
  Rank                     none (0)
  Long-name                cudastitcher
  Klass                    RR Cuda Stitcher
  Description              Allows frames to be stitched by the GPU using a custom CUDA library algorithm.
			 Multiple inputs single output topology.
  Author                   Luis Murillo <luis.murillo@ridgerun.com>
			Emmanuel Madrigal <emmanuel.madrigal@ridgerun.com>

Plugin Details:
  Name                     cudastitcher
  Description              RidgeRun Stitcher
  Filename                 /usr/lib/gstreamer-1.0/libgstcudastitcher.so
  Version                  1.2.5
  License                  Proprietary
  Source module            rrstitcher
  Binary package           rrstitcher
  Origin URL               https://ridgerun.com/

```